### PR TITLE
Add MVP feature spec for volunteer jobs board

### DIFF
--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -143,9 +143,10 @@ Interest
 | Rich text | Action Text | Ships with Rails, handles descriptions well |
 | File uploads | Active Storage (local disk for dev, S3 for prod) | Ships with Rails |
 | Search | `pg_search` or `WHERE ... ILIKE` | Postgres-native full-text search |
-| Pagination | Pagy or `will_paginate` | Lightweight, well-supported |
-| CSS | Tailwind CSS or Pico CSS via CDN | Fast to style without a build step |
+| Pagination | Pagy | Lightweight, fast, well-supported |
+| CSS | Tailwind CSS | Utility-first CSS framework |
 | JS | Turbo + Stimulus (Hotwire) | Already configured in Rails 8 |
+| Testing | RSpec | Preferred over Minitest; use FactoryBot + Shoulda Matchers |
 | Authorization | Simple `before_action` checks | No Pundit/CanCanCan needed; check membership + site_admin |
 
 ## Page Map


### PR DESCRIPTION
Defines the core product scope: user roles (Volunteer, Org Admin,
Site Admin), data model, critical MVP features (auth, orgs, listings,
browse/search, interest expression), and explicitly defers non-critical
features (messaging, OAuth, notifications) to post-MVP for faster
time to market.

https://claude.ai/code/session_01C63y7866AB15BXXGkP8ePM