### PR TITLE
Improve interest notification email and add Mission Control Jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "jbuilder"
 
 gem "sentry-ruby"
 gem "sentry-rails"
+gem "mission_control-jobs"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,16 @@ GEM
     minitest (6.0.2)
       drb (~> 2.0)
       prism (~> 1.5)
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.8.0)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
@@ -513,6 +523,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  mission_control-jobs
   omniauth
   omniauth-github (~> 2.0)
   omniauth-linkedin-openid

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bin/rails server
 css: bin/rails tailwindcss:watch
+worker: bin/jobs
 mail: mailhog

--- a/app/mailers/interest_mailer.rb
+++ b/app/mailers/interest_mailer.rb
@@ -6,6 +6,8 @@ class InterestMailer < ApplicationMailer
     @recipient = recipient
     @interest_url = listing_interest_detail_url(@listing, interest)
 
-    mail subject: "New interest in #{@listing.title} (#{@organization.name})", to: recipient.email_address
+    mail subject: "New interest in #{@listing.title} (#{@organization.name})",
+         to: recipient.email_address,
+         reply_to: @interest.user.email_address
   end
 end

--- a/app/views/interest_mailer/new_interest.html.erb
+++ b/app/views/interest_mailer/new_interest.html.erb
@@ -1,11 +1,17 @@
 <p>Hi <%= @recipient.name %>,</p>
 
 <p>
-  Someone has expressed interest in your listing
+  <%= @interest.user.name %> has expressed interest in your listing
   <strong><%= @listing.title %></strong>
   at <%= @organization.name %>.
 </p>
 
+<% if @interest.message.present? %>
+  <p><strong>Their message:</strong></p>
+  <blockquote><%= simple_format(@interest.message) %></blockquote>
+<% end %>
+
 <p>
   <%= link_to "View details", @interest_url %> to review their interest.
+  You can also reply directly to this email to respond.
 </p>

--- a/app/views/interest_mailer/new_interest.text.erb
+++ b/app/views/interest_mailer/new_interest.text.erb
@@ -1,5 +1,13 @@
 Hi <%= @recipient.name %>,
 
-Someone has expressed interest in your listing "<%= @listing.title %>" at <%= @organization.name %>.
+<%= @interest.user.name %> has expressed interest in your listing "<%= @listing.title %>" at <%= @organization.name %>.
+<% if @interest.message.present? %>
+
+Their message:
+
+<%= @interest.message %>
+<% end %>
 
 View details: <%= @interest_url %>
+
+You can also reply directly to this email to respond.

--- a/config/initializers/mission_control_jobs.rb
+++ b/config/initializers/mission_control_jobs.rb
@@ -1,0 +1,2 @@
+MissionControl::Jobs.base_controller_class = "Admin::DashboardController"
+MissionControl::Jobs.http_basic_auth_enabled = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     resources :listings, only: [ :index, :update ]
     resources :flags, only: [ :index, :update ]
     resources :users, only: :index
+    mount MissionControl::Jobs::Engine, at: "/jobs"
   end
 
   # OmniAuth callbacks

--- a/lib/tasks/seed_synthetic.rake
+++ b/lib/tasks/seed_synthetic.rake
@@ -156,7 +156,8 @@ namespace :dev do
         bio: bios.sample,
         portfolio_url: [ nil, nil, "https://#{first.downcase}#{last.downcase.gsub("'", "")}.dev", "https://github.com/#{first.downcase}#{last.downcase.gsub("'", "")}" ].sample,
         github_username: rand < 0.6 ? "#{first.downcase}#{last.downcase.gsub("'", "")}#{i}" : nil,
-        linkedin_username: rand < 0.4 ? "#{first.downcase}-#{last.downcase.gsub("'", "")}-#{rand(1000)}" : nil
+        linkedin_username: rand < 0.4 ? "#{first.downcase}-#{last.downcase.gsub("'", "")}-#{rand(1000)}" : nil,
+        email_confirmed_at: Time.current
       )
       users << user
     end

--- a/test/mailers/interest_mailer_test.rb
+++ b/test/mailers/interest_mailer_test.rb
@@ -48,11 +48,31 @@ class InterestMailerTest < ActionMailer::TestCase
     assert_not_nil mail.text_part, "Expected a text part"
   end
 
-  test "new_interest body does not reveal the interested user's identity" do
+  test "new_interest sets reply-to as the interested user's email" do
+    mail = InterestMailer.new_interest(@interest, @owner)
+
+    assert_equal [ @interested_user.email_address ], mail.reply_to
+  end
+
+  test "new_interest body includes the interested user's name" do
     mail = InterestMailer.new_interest(@interest, @owner)
     body = mail.body.encoded
 
-    assert_no_match @interested_user.name, body
-    assert_no_match @interested_user.email_address, body
+    assert_match @interested_user.name, body
+  end
+
+  test "new_interest body includes the interest message" do
+    mail = InterestMailer.new_interest(@interest, @owner)
+    body = mail.body.encoded
+
+    assert_match "I'd love to help!", body
+  end
+
+  test "new_interest body omits message section when message is blank" do
+    @interest.update!(message: "")
+    mail = InterestMailer.new_interest(@interest, @owner)
+    body = mail.body.encoded
+
+    assert_no_match "Their message", body
   end
 end


### PR DESCRIPTION
- Include interested party's name, message, and reply-to email in notification so org owners can respond directly
- Add worker process to Procfile.dev so background jobs are processed
- Fix mission_control-jobs initializer to use class-level config
- Confirm seeded user emails so notifications pass the filter
- Add mission_control-jobs gem and mount engine in admin routes